### PR TITLE
Fixes for database connection from client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
   global:
-    - NAME=sammonsjl/mythtv
+    - NAME=pkendall64/mythtv
     - VERSION=30-fixes
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-key adv --recv-keys --keyserver \
 	&& chmod a+x /usr/bin/tv_grab_nz-py \
 	\
 	&& sed -i 's/3306/6506/g' /etc/mysql/mariadb.conf.d/50-server.cnf \
+	&& sed -i 's/127.0.0.1/0.0.0.0/g' /etc/mysql/mariadb.conf.d/50-server.cnf \
 	\
 	&& cd /opt && git clone https://github.com/kanaka/noVNC.git \
 	&& cd noVNC/utils && git clone \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,10 @@ RUN apt-key adv --recv-keys --keyserver \
 		git x11vnc xvfb mate-desktop-environment-core net-tools \
 	\
 	&& apt-get install -y  \
-		mythtv-backend-master mythweb \
+		mythtv-backend-master mythweb xmltv xmltv-util \
+	\
+	&& wget https://nice.net.nz/scripts/tv_grab_nz-py -O /usr/bin/tv_grab_nz-py \
+	&& chmod a+x /usr/bin/tv_grab_nz-py \
 	\
 	&& sed -i 's/3306/6506/g' /etc/mysql/mariadb.conf.d/50-server.cnf \
 	\

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The graphical interface of the application can be accessed via:
 
   * A web browser:
 ```
-http://<HOST IP ADDR>:6700
+http://<HOST IP ADDR>:6570
 ```
 
 ## Shell Access

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Where:
   - `/docker/appdata/mythtv/data`: This is where MythTV stores it's MariaDB database.
   - `/docker/appdata/mythtv/media`: This is where MythTV stores it's media files such as recordings.
 
-Browse to `http://your-host-ip:6507` to access the Mate Desktop GUI.  From here MythTV can be configured using the MythTV Backend Setup shortcut.  MythTV can be also be tested using the MythTV Backend Startup shortcut.  Setting the variable CONFIG_MODE=0 will disable the GUI and properly configure S6 to control mythbackend startup.
+Browse to `http://your-host-ip:6570` to access the Mate Desktop GUI.  From here MythTV can be configured using the MythTV Backend Setup shortcut.  MythTV can be also be tested using the MythTV Backend Startup shortcut.  Setting the variable CONFIG_MODE=0 will disable the GUI and properly configure S6 to control mythbackend startup.
 
 ## Usage
 
@@ -94,7 +94,7 @@ of this parameter has the format `<VARIABLE_NAME>=<VALUE>`.
 |`USERID`| ID of the user the application runs as.  See [User/Group IDs](#usergroup-ids) to better understand when this should be set. | `120` |
 |`GROUPID`| ID of the group the application runs as.  See [User/Group IDs](#usergroup-ids) to better understand when this should be set. | `121` |
 |`TZ`| [TimeZone] of the container.  Timezone can also be set by mapping `/etc/localtime` between the host and the container. | `America/Chicago"` |
-|`CONFIG_MODE`| When set to `1`, The mythbackend service will be disabled and a Mate Desktop will be started at: `http://your-host-ip:6507`. | `1` |
+|`CONFIG_MODE`| When set to `1`, The mythbackend service will be disabled and a Mate Desktop will be started at: `http://your-host-ip:6570`. | `1` |
 
 ### Data Volumes
 


### PR DESCRIPTION
Hi,
this is the same as the commits to the 0.29 branch that opens the database connection so remote clients can connect.
Also, a couple of small fixes to the docs and adding XMLTV support, along with the NZ epg provider.