### PR TITLE
JM: work around myth 30 install issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,13 @@ services:
       - ./shared:/shared
     hostname: mythbackend
     network_mode: "host"
+    ports:
+      - "6506:6506"
+      - "6543:6543"
+      - "6544:6544"
+      - "6554:6554"
+      - "6570:6570"
+      - "6580:6580"
 volumes:
   config:
   data:


### PR DESCRIPTION
Hi. I noticed that there appears to be a permissions issue with the mythtv-common installation for version 30. It creates a temp file with the wrong ownership so the package does not install. I work around this by hacking out the ownership changes from the mythtv postinst script then setting the permissions in the dockerfile after configuration instead. 